### PR TITLE
Updated initial subsidy to 1.5625 and halving schedule to every 210,000 blocks.

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -331,35 +331,35 @@ BlockController.prototype.formatTimestamp = function(date) {
 };
 
 BlockController.prototype.getBlockReward = function(height) {
-  var subsidy = new BN(12.5 * 1e8);
-
-  // Mining slow start
-  // The subsidy is ramped up linearly, skipping the middle payout of
-  // MAX_SUBSIDY/2 to keep the monetary curve consistent with no slow start.
-
-//  if (height < (2 / 2)) {
-//    subsidy /= 2;
-//    subsidy *= height;
-//    return subsidy;
-//  } else if (height < 2) {
-//    subsidy /= 2;
-//    subsidy *= (height+1);
-//   return subsidy;
-//  }
-
-if (height < 2) {
-      subsidy /= 2;
-      subsidy *= (height+1);
-      return subsidy;
-}
-
-  var halvings = Math.floor((height - (2/2)) / 840000);
+  // TODO: this figure should ultimately come from the daemon as the authoritative source, not calculated here! Current approach should be considered a quick, temporary fix.
+ 
+  // genesis block
+  if (height == 0) {
+  	return 0;
+  }
+  
+  // blocks up to and including the snapshot
+  if (height <= 272991) {
+   	return BN(12.5 * 1e8);
+  }
+  
+  // initial BTCP block subsidy 
+  var subsidy = new BN(1.5625 * 1e8);
+  
+  var firstSubsidizedBlock = 278459;
+  
+  if (height < firstSubsidizedBlock) {
+  	return subsidy;
+  }
+    
+  // halving consideration starts with 1st subsidized BTCP block
+  var halvings = Math.floor((height - firstSubsidizedBlock) / 210000);
   // Force block reward to zero when right shift is undefined.
   if (halvings >= 64) {
     return 0;
   }
 
-  // Subsidy is cut in half every 840,000 blocks which will occur approximately every 4 years.
+  // Subsidy is cut in half every 210000 blocks which will occur approximately every 1 year.
   subsidy = subsidy.shrn(halvings);
 
   return parseInt(subsidy.toString(10));


### PR DESCRIPTION
Updated initial subsidy to 1.5625 and the halving schedule to every 210,000 blocks as a quick, temporary fix. Eventually the daemon should be the ultimate authority on subsidy for any given block so that the schedule is not duplicated here, especially given the possibility of changes through to the mining subsidy in the future through BIP9.